### PR TITLE
Start GeoLocation only on iPhone and Android with GMS enabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "react-native-code-push": "^6.2.0",
     "react-native-config": "^1.0.0",
     "react-native-contact-tracer": "git://github.com/Morchana/contact-tracer.git",
-    "react-native-device-info": "^5.5.3",
+    "react-native-device-info": "^8.0.0",
     "react-native-easy-grid": "^0.2.0",
     "react-native-elements": "^1.2.7",
     "react-native-event-listeners": "^1.0.7",

--- a/src/services/background-tracking.ts
+++ b/src/services/background-tracking.ts
@@ -3,6 +3,7 @@ import { getAnonymousHeaders } from '../api'
 import { Platform } from 'react-native'
 import { API_URL } from '../config'
 import I18n from '../../i18n/i18n'
+import DeviceInfo from 'react-native-device-info'
 class BackgroundTracking {
   setup(startImmediately?: boolean) {
     if (startImmediately) {
@@ -57,6 +58,9 @@ class BackgroundTracking {
   }
 
   start() {
+    if (!this.canUseGeoLocation) {
+      return Promise.resolve()
+    }
     return this.registerGeoLocation().then((state) => {
       if (!state.enabled) {
         BackgroundGeolocation.start().catch(console.log)
@@ -65,21 +69,35 @@ class BackgroundTracking {
   }
 
   stop() {
+    if (!this.canUseGeoLocation) {
+      return Promise.resolve()
+    }
     BackgroundGeolocation.removeAllListeners()
     return BackgroundGeolocation.stop()
   }
 
   destroyLocations() {
+    if (!this.canUseGeoLocation) {
+      return Promise.resolve()
+    }
     return BackgroundGeolocation.destroyLocations()
   }
 
   getLocation(extras: any = {}) {
+    if (!this.canUseGeoLocation) {
+      return Promise.resolve({ ...extras })
+    }
     return this.registerGeoLocation().then(() => {
       return BackgroundGeolocation.getCurrentPosition({
         samples: 1,
         ...extras,
       })
     })
+  }
+
+  get canUseGeoLocation() {
+    const hasGMS = DeviceInfo.hasGmsSync()
+    return Platform.OS === 'ios' || hasGMS
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7983,10 +7983,10 @@ react-native-datepicker@^1.4.4:
   dependencies:
     moment "^2.22.0"
 
-react-native-device-info@^5.5.3:
-  version "5.5.4"
-  resolved "https://registry.yarnpkg.com/react-native-device-info/-/react-native-device-info-5.5.4.tgz#470770db4e8a35c55b8269473d81790102074057"
-  integrity sha512-koR7ZvL4V+34GwhjQxb3PNZLElpEzAvDG5AE4KIc70ufKMEHJL9VCpRXBMelihlA0u9PlYzuMgBs7tovNRAzFw==
+react-native-device-info@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/react-native-device-info/-/react-native-device-info-8.0.0.tgz#a481ea6d445483329aefcb91c753987931ad4756"
+  integrity sha512-7/DOEhg8GtyW1hpVtWf8F6RvGLaFaOGmex+IkmiBWQC2uW4NFDcfXm+lMMZnduFavTyUTX7AF6lAM3y286cEfA==
 
 react-native-drawer-menu@^0.2.3:
   version "0.2.5"


### PR DESCRIPTION
This version only remove the dialog "GMS unavailable" from the onboarding stage due to the lack of GMS on Huawei phone

This PR is similar to https://github.com/codeforpublic/SQUID/pull/56 but uses `hasGMS` detection function from `react-native-device-info` instead