### PR TITLE
Fix unlocalized texts and typo in update avatar alerts

### DIFF
--- a/i18n/locales/en.js
+++ b/i18n/locales/en.js
@@ -65,8 +65,8 @@ export default {
   connect_internet_to_update: 'connect the internet to update',
   for_checking_in_with_qr: 'for checking in with QR Code',
   press_to_confirm: 'Confirm',
-  can_not_change_picture: 'Can not change picture',
-  can_change_pic_again_in: 'You can change picture again in ',
+  can_not_change_picture: 'Cannot change picture',
+  can_change_pic_again_in: 'You can change picture again in',
   day_s: 'day(s)',
   are_you_sure: 'Are you sure?',
   after_changed_pic_you_will_not_be_able_to_change_until:

--- a/src/navigations/3-MainApp/MainApp/UpdateProfileButton.tsx
+++ b/src/navigations/3-MainApp/MainApp/UpdateProfileButton.tsx
@@ -29,7 +29,7 @@ export const UpdateProfileButton = ({ width, style, onChange }) => {
           const day = DEFAULT_PERIODS - daySinceUpdated
           Alert.alert(
             I18n.t('can_not_change_picture'),
-            'คุณจะสามารถเปลี่ยนรูปได้อีกใน ' + day + I18n.t('day_s'),
+            I18n.t('can_change_pic_again_in') + ' ' + day + ' ' + I18n.t('day_s'),
           )
         } else {
           navigation.navigate('MainAppFaceCamera', {
@@ -37,7 +37,7 @@ export const UpdateProfileButton = ({ width, style, onChange }) => {
               if (daySinceCreated >= 3) {
                 Alert.alert(
                   I18n.t('are_you_sure'),
-                  `I18n.t('after_changed_pic_you_will_not_be_able_to_change_until') ${DEFAULT_PERIODS} I18n.t('day_s_have_passed')`,
+                  `${I18n.t('after_changed_pic_you_will_not_be_able_to_change_until')} ${DEFAULT_PERIODS} ${I18n.t('day_s_have_passed')}`,
                   [
                     { text: I18n.t('cancel'), style: 'cancel' },
                     {


### PR DESCRIPTION
# Current behavior
When language is English:
1. Text in warning alert of the next avatar change unformatted "I18n.t('after_changed_pic_you_will_not_be_able_to_change_until') 7 I18n.t('day_s_have_passed')"
2. Text in error alert of avatar cannot be changed is hardcoded "คุณจะสามารถเปลี่ยนรูปได้อีกใน 4days(s)"
3. Title in error alert of avatar cannot be changed "Can not" is spelled incorrectly
![device-2021-01-18-225023](https://user-images.githubusercontent.com/10735822/104938607-e33ef600-59e1-11eb-84c9-77e06b35824c.png) ![device-2021-01-18-224450](https://user-images.githubusercontent.com/10735822/104938618-e803aa00-59e1-11eb-92e4-7d838d528804.png)

# Expected behavior
1. Text in warning alert of the next avatar change should be "After you changed picture, you will not be able to change the picture again until 7 days(s) have passed"
2. Text in error alert of avatar cannot be changed should be "You can change picture again in 4 day(s)"
3. Title in error alert of avatar cannot be changed should be "Cannot"

# About this change
Fix unlocalized texts and typo in update avatar alerts