### PR TITLE
Automatically generate a debug APK on GitHub Actions

### DIFF
--- a/.github/workflows/build-android-debug.yml
+++ b/.github/workflows/build-android-debug.yml
@@ -1,0 +1,16 @@
+name: Build Debug Android Package
+on:
+  push:
+    branches:
+      - master
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          docker-compose run builder bash -c 'yarn && cd android && ./gradlew assembleDebug'
+      - uses: actions/upload-artifact@v2
+        with:
+          name: app-debug-apk
+          path: android/app/build/outputs/apk/debug/app-debug.apk

--- a/.github/workflows/build-android-debug.yml
+++ b/.github/workflows/build-android-debug.yml
@@ -8,6 +8,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
+      # https://github.com/expo/expo-github-action/issues/20#issuecomment-541676895
+      - name: Setup kernel for React Native, increase watchers
+        run: |
+          echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
       - run: |
           docker-compose run builder bash -c 'yarn && cd android && ./gradlew assembleDebug'
       - uses: actions/upload-artifact@v2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3.8'
+services:
+  builder:
+    image: reactnativecommunity/react-native-android
+    working_dir: /usr/src/app
+    volumes:
+      - ./:/usr/src/app
+      - /usr/src/app/node_modules


### PR DESCRIPTION
Similar to how [VSCodium](https://vscodium.com/) is an [open-source binary distribution](https://vscodium.com/#why:~:text=The%20VSCodium%20project%20exists%20so%20that,binaries%20for%20you%20to%20GitHub%20releases.) of VS Code, this workflow builds an APK file ready to be installed. Since it is built on GitHub Actions, all the process involved in building is transparent and open, so the generated binaries can be trusted.

**Important note:** This workflow generates a debug APK with the default `.env` file pointing to **development backend.** Not sure if this would cause confusion… maybe better to generate an APK that points to the actual production backend?? It could be bad if people actually use the generated APKs here<sup>1</sup> not knowing that the software is interfacing with the development backend and not the real backend, because then contract tracing would not work for that person... Elaborated in issue #71.

![image](https://user-images.githubusercontent.com/193136/105081593-f676c200-5ac4-11eb-8572-b6d6b6e459c1.png)

GitHub Actions Run URL: https://github.com/dtinth/SQUID/actions/runs/496771323

**Footnotes:**
<sup>1</sup> Some people may fear that the app published on the store may not match the source code on GitHub, so they might prefer to install binaries that are built by public CI servers instead.